### PR TITLE
Improve event style

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -1,5 +1,7 @@
 import EventDetails from '@/components/events/EventDetails';
-import { PageLayout, PageSectionTitle, PageTitle } from '@/components/layout/PageLayout';
+import { PageLayout, PageTitle } from '@/components/layout/PageLayout';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -11,9 +13,13 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
 
   return (
     <PageLayout>
-      <PageTitle>Wydarzenia</PageTitle>
-      <PageSectionTitle>Aktywne wydarzenia</PageSectionTitle>
-      <EventDetails id={parsedId} />
+      <PageTitle>Wydarzenie</PageTitle>
+      <div className="flex flex-col items-center gap-4">
+        <EventDetails id={parsedId} />
+        <Link href="/events">
+          <Button>Pokaż wszystkie</Button>
+        </Link>
+      </div>
     </PageLayout>
   );
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,6 +1,6 @@
 import { PageLayout, PageTitle } from '@/components/layout/PageLayout';
 import { trpc } from '@/trpc/server';
-import EventDetails from '@/components/events/EventDetails';
+import Event from '@/components/events/Event';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { EventDTO } from '@/types/Event';
 
@@ -12,7 +12,7 @@ function EventList({ events }: EventListProps) {
   return (
     <div className="flex flex-col gap-4">
       {events.map((event) => (
-        <EventDetails key={event.id} id={event.id} />
+        <Event key={event.id} id={event.id} />
       ))}
     </div>
   );

--- a/components/events/EventVisitedStatus.tsx
+++ b/components/events/EventVisitedStatus.tsx
@@ -1,0 +1,24 @@
+import { QrCode } from 'lucide-react';
+
+type Props = {
+  visited: boolean;
+  ended: boolean;
+};
+
+export default function EventVisitedStatus({ visited, ended }: Props) {
+  return (
+    <>
+      {visited ? (
+        <div className="flex gap-2">
+          <QrCode className="text-success" /> Wydarzenie odwiedzone
+        </div>
+      ) : (
+        !ended && (
+          <div className="flex gap-2">
+            <QrCode className="text-info" /> Zeskanuj kod QR!
+          </div>
+        )
+      )}
+    </>
+  );
+}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin] max-w-[calc(100vw-1rem)] m-2",
         className
       )}
       {...props}


### PR DESCRIPTION
## Zmiany
- Większy line height tytułu
- Czas trwania pod kierunkami a nie obok
- Tylko najbliższy/trwający czas trwania wyświetlony na liście z przyciskiem zobacz więcej przekierowującym do szczegółów
- Informacja żeby zeskanować qr wyświetlona tylko jak wydarzenie nie minęło już całe. Informacja o zeskanowanym wyświetlana zawsze
- Gdy tylko jedno occurence, przycisk mówi pokaż szczegóły zamiast pokaż więcej occurence
- Poprawiony tooltip kierunku żeby łamał linię zamiast wystawać poza ekran gdy się nie mieści
- Lokalizacja w tej lini co rodzaj wydarzenia a dopiero niżej tytuł, bo bardziej pasuje z dłuższymi tytułami i się tak nie łamią


## Screeny

### Wydarzenie które jeszcze się nie skończyło:

![image](https://github.com/user-attachments/assets/221ae644-e780-49a4-8085-6eb3bed3caba)

### Zakończone wydarzenie

![image](https://github.com/user-attachments/assets/8d406718-7849-459d-b06b-2d15c51d8c08)
