### PR TITLE
133 szczegóły zadania są dobrze wyświetlane zgodnie z endpointem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 *.db
 *.db-journal
 /cypress/screenshots/
+cypress.env.json

--- a/components/events/Event.tsx
+++ b/components/events/Event.tsx
@@ -44,19 +44,24 @@ export default async function Event({ id, data, showDetails = false }: Props) {
             <Link
               href={`/map?event=${event.id}`}
               className="flex shrink-0 items-center gap-2 hover:underline"
+              data-testid="event-location"
             >
               <MapPin />
               {event.building.name}, {event.building.room}, {event.building.floor}
             </Link>
           </div>
-          <CardTitle className="leading-tight">{event.name}</CardTitle>
+          <CardTitle className="leading-tight" data-testid={'event-title'}>
+            {event.name}
+          </CardTitle>
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-y-4">
-        <p className="text-sm text-muted-foreground">{event.description}</p>
+        <p className="text-sm text-muted-foreground" data-testid={'event-description'}>
+          {event.description}
+        </p>
         <div>
           <p>{event.fieldOfStudy.length == 1 ? 'Powiązany kierunek:' : 'Powiązane kierunki:'}</p>
-          <div className="mt-2 flex flex-wrap items-start gap-2">
+          <div className="mt-2 flex flex-wrap items-start gap-2" data-testid="event-field-of-study">
             {event.fieldOfStudy.map((f) => (
               <FieldOfStudyBadge key={f.id} fieldOfStudy={f} />
             ))}
@@ -65,7 +70,7 @@ export default async function Event({ id, data, showDetails = false }: Props) {
         {showDetails ? (
           <div>
             <p>Czas trwania:</p>
-            <div className="mt-1 flex flex-col gap-1">
+            <div className="mt-1 flex flex-col gap-1" data-testid="event-occurrences">
               {event.occurrences.map((o) => (
                 <EventOccurrence
                   key={o.start.toString()}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,4 +12,11 @@ export default defineConfig({
       return config;
     },
   },
+
+  e2e: {
+    setupNodeEvents(on, config) {
+      config.baseUrl = 'http://localhost:3000';
+      return config;
+    },
+  },
 });

--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,0 +1,4 @@
+{
+  "user_email": "<email>",
+  "user_password": "<password>"
+}

--- a/cypress/e2e/eventDetails.cy.ts
+++ b/cypress/e2e/eventDetails.cy.ts
@@ -1,0 +1,70 @@
+import { trpc } from '../support/trpc-client';
+import { EventDTO } from '@/types/Event';
+
+describe('Event details', () => {
+  let event: EventDTO;
+
+  before(() => {
+    cy.wrap(
+      trpc.events.getEvents.query({}).then((events) => {
+        expect(events).to.have.length.greaterThan(0);
+        event = events[0];
+      })
+    ).then(() => {
+      cy.setCookie('seen_welcome', 'true');
+      cy.visit(`/events/${event.id}`);
+    });
+  });
+
+  beforeEach(() => {
+    cy.setCookie('seen_welcome', 'true');
+    cy.visit(`/events/${event.id}`);
+  });
+
+  it('should display the correct event title', () => {
+    cy.getById('event-title').should('contain', event.name);
+  });
+
+  it('should display the correct event description', () => {
+    cy.getById('event-description').should('contain', event.description);
+  });
+
+  it('should display the correct event location', () => {
+    cy.getById('event-location').should(
+      'contain',
+      `${event.building.name}, ${event.building.room}, ${event.building.floor}`
+    );
+  });
+
+  it('should display the correct fields of study', () => {
+    cy.getById('event-field-of-study')
+      .children()
+      .should('have.length', event.fieldOfStudy.length)
+      .each((element, index) => {
+        expect(element.text().trim()).to.equal(event.fieldOfStudy[index].name);
+      });
+  });
+
+  it('should display the correct event type', () => {
+    cy.getById('EventTypeBadge').should('contain', event.eventType.name);
+  });
+
+  it('should display the correct occurrences', () => {
+    cy.getById('event-occurrences')
+      .children()
+      .should('have.length', event.occurrences.length)
+      .each((element, index) => {
+        const occurrence = event.occurrences[index];
+        const startTime = new Date(occurrence.start).toLocaleTimeString('pl-PL', {
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+        const endTime = new Date(occurrence.end).toLocaleTimeString('pl-PL', {
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+        const formattedTime = `${startTime} - ${endTime}`;
+        cy.wrap(element).should('contain', formattedTime);
+      });
+  });
+});

--- a/cypress/e2e/login.cy.ts
+++ b/cypress/e2e/login.cy.ts
@@ -1,0 +1,31 @@
+describe('User can login successfully', () => {
+  const email = Cypress.env('user_email');
+  const password = Cypress.env('user_password');
+
+  it('passes', async () => {
+    // Visits main page
+    cy.visit('/');
+
+    // Closes intro overlay
+    cy.get('button[data-testid="close-welcome-overlay"]').click();
+    // Goes to settings page
+    cy.get('a[href="/settings"]', { timeout: 10000 }).click();
+
+    // Goes to login page
+    cy.get('button[data-testid="AuthButton"]').contains('Zaloguj się').click();
+
+    // Fills in login form and submits
+    cy.get('input[name="email"]').type(email);
+    cy.get('input[name="password"]').type(password);
+    cy.get('button[type="submit"]').click();
+
+    // Waits for the redirection to the map page
+    cy.url({ timeout: 10000 }).should('include', '/map');
+
+    // Goes to settings page again
+    cy.get('a[href="/settings"]').click();
+
+    // Checks whether the user email is displayed in the account settings
+    cy.get('span').contains(email).should('exist');
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,17 @@
+// ***********************************************************
+// This example support/e2e.ts is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';

--- a/cypress/support/trpc-client.tsx
+++ b/cypress/support/trpc-client.tsx
@@ -1,0 +1,26 @@
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { AppRouter } from '@/trpc/router';
+import superjson from 'superjson';
+
+function getUrl() {
+  const base = (() => {
+    if (typeof window !== 'undefined') return '';
+    if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    return 'http://localhost:3000';
+  })();
+  return `${base}/api/trpc`;
+}
+
+export const trpc = createTRPCClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      transformer: superjson,
+      url: getUrl(),
+      headers: () => {
+        const headers = new Headers();
+        headers.set('x-trpc-source', 'nextjs-react');
+        return headers;
+      },
+    }),
+  ],
+});

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,8 +1,15 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["cypress"]
+    "types": [
+      "cypress"
+    ],
+    "baseUrl": "../"
   },
   "exclude": [],
-  "include": ["../cypress.config.ts", "./**/*.ts", "./**/*.tsx"]
+  "include": [
+    "../cypress.config.ts",
+    "./**/*.ts",
+    "./**/*.tsx"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "cy:open": "cypress open",
-    "cy:run": "cypress run --component"
+    "cy:unit": "cypress run --component",
+    "cy:e2e": "cypress run --e2e"
   },
   "dependencies": {
     "@hookform/resolvers": "^4.1.3",


### PR DESCRIPTION
Bazujące na https://github.com/AGH-Code-Industry/how-to-agh-reboot/pull/132

- Klient trpc do testów
- Rozdzielenie skryptów pnpm z `cy:run` na `cy:unit` i `cy:e2e`
- Testy integracyjne strony szczegółów wydarzenia (bez włączania powiadomień, co można dodać w przyszłości pod warunkiem odpowiednich przygotowanych danych, aby wydarzenie było w przyszłości)